### PR TITLE
Remove unused function that is now in shared Jenkinslib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,13 +28,3 @@ pipeline {
         }
     }
 }
-
-def getAccountNumberFromStage() {
-    def stageToAccountMap = [
-            "intg": env.INTG_ACCOUNT,
-            "staging": env.STAGING_ACCOUNT,
-            "prod": env.PROD_ACCOUNT
-    ]
-
-    return stageToAccountMap.get(params.STAGE)
-}


### PR DESCRIPTION
This change removes the original getAccountNumberFromStage function from the Jenkinsfile. It is not currently being used, but if needed it can be called from the shared Jenkinslib.