### PR TITLE
Remove stage parameter.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 library("tdr-jenkinslib")
 
 sbtReleaseDeployJob(
-  stage: params.STAGE,
   buildNumber: BUILD_NUMBER,
   libraryName: "Auth utils",
   repo: "tdr-auth-utils"


### PR DESCRIPTION
The sbtReleaseDeployJob has been updated to use the s3Publish task
definition rather than one which has the stage in the name so the stage
parameter is no longer needed.