### PR TITLE
Change user type to return boolean value

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/keycloak/Token.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/keycloak/Token.scala
@@ -13,8 +13,8 @@ class Token(private val token: AccessToken, val bearerAccessToken: BearerAccessT
   // The method to get the token verifies that the user_id is set so this should never be empty
   def userId: UUID = UUID.fromString(getOtherClaim("user_id").get)
   def transferringBody: Option[String] = getOtherClaim("body")
-  def judgmentUser: Option[String] = getOtherClaim("judgment_user")
-  def standardUser: Option[String] = getOtherClaim("standard_user")
+  def isJudgmentUser: Boolean = getOtherClaim("judgment_user").getOrElse("false").toBoolean
+  def isStandardUser: Boolean = getOtherClaim("standard_user").getOrElse("false").toBoolean
   def roles: Set[String] =
     Option(token.getResourceAccess("tdr")) match {
       case Some(access) => access.getRoles.asScala.toSet

--- a/src/test/scala/uk/gov/nationalarchives/tdr/keycloak/KeycloakUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/keycloak/KeycloakUtilsTest.scala
@@ -41,18 +41,46 @@ class KeycloakUtilsTest extends ServiceTest {
     token.transferringBody should equal(Some(body))
   }
 
-  "The token method " should "return judgment user type 'true' for a valid token" in {
+  "The token method " should "return judgment user type 'true' where claim set to true" in {
     implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
     val mockToken = mock.getAccessToken(configWithUser.withClaim("judgment_user", "true").build())
     val token = utils.token(mockToken).right.value
-    token.judgmentUser should equal(Some("true"))
+    token.isJudgmentUser should equal(true)
   }
 
-  "The token method " should "return standard user type 'true' for a valid token" in {
+  "The token method " should "return judgment user type 'false' where claim set to false" in {
+    implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
+    val mockToken = mock.getAccessToken(configWithUser.withClaim("judgment_user", "false").build())
+    val token = utils.token(mockToken).right.value
+    token.isJudgmentUser should equal(false)
+  }
+
+  "The token method" should "return judgment user type 'false' where claim not set" in {
+    implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
+    val mockToken = mock.getAccessToken(configWithUser.build())
+    val token = utils.token(mockToken).right.value
+    token.isJudgmentUser should equal(false)
+  }
+
+  "The token method " should "return standard user type 'true' where claim set to true" in {
     implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
     val mockToken = mock.getAccessToken(configWithUser.withClaim("standard_user", "true").build())
     val token = utils.token(mockToken).right.value
-    token.standardUser should equal(Some("true"))
+    token.isStandardUser should equal(true)
+  }
+
+  "The token method " should "return standard user type 'false' where claim set to false" in {
+    implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
+    val mockToken = mock.getAccessToken(configWithUser.withClaim("standard_user", "false").build())
+    val token = utils.token(mockToken).right.value
+    token.isStandardUser should equal(false)
+  }
+
+  "The token method " should "return standard user type 'false' where claim not test" in {
+    implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(url, "tdr", 3600)
+    val mockToken = mock.getAccessToken(configWithUser.build())
+    val token = utils.token(mockToken).right.value
+    token.isStandardUser should equal(false)
   }
 
   "The token method " should "return the correct roles for a valid token" in {


### PR DESCRIPTION
To better support client's using the library return a boolean value based on whether the user type claims are set, or the value set

Saves clients having to handle the optional string, converting it to a boolean