### PR TITLE
Use contains.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   deploy:
-    if: ${{ !startsWith( github.event.commits[0].message, 'Version Bump from build number') }}
+    if: ${{ !contains( github.event.commits[0].message, 'Version Bump from build number') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
For some reason, the commits now have extra words in them that means
this check fails and we're deploying in a loop.

This should fix it.
