### PR TITLE
Don't deploy on version bumps.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 name: Deploy if not a version bump PR
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types:
+      - closed
 jobs:
   deploy:
-    if: ${{ !contains( github.event.commits[0].message, 'Setting version to') }}
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'Version bump') }}
     steps:
       - uses: actions/checkout@v2
       - run: gh workflow run deploy.yml


### PR DESCRIPTION
This will only run when a PR is merged and it doesn't have the version
bump label.

The label is set in the release job when the PR is created.
