### PR TITLE
dependency updates

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   private lazy val circeVersion = "0.14.1"
   private lazy val keycloakVersion = "16.1.0"
-  private lazy val softWareMillVersion = "2.1.1"
+  private lazy val softWareMillVersion = "2.3.0"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.0-M2"
   lazy val keycloakAdapterCore  = "org.keycloak" % "keycloak-adapter-core" % keycloakVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private lazy val circeVersion = "0.13.0"
+  private lazy val circeVersion = "0.14.1"
   private lazy val keycloakVersion = "16.1.0"
   private lazy val softWareMillVersion = "2.1.1"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val httpComponents = "org.apache.httpcomponents" % "httpclient" % "4.5.11"
   lazy val jbossLogging = "org.jboss.logging" % "jboss-logging" % "3.4.1.Final"
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.11.0"
-  lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0"
+  lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3"
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "7.1.3"
   lazy val sttp = "com.softwaremill.sttp.client" %% "core" % softWareMillVersion
   lazy val sttpCirce = "com.softwaremill.sttp.client" %% "circe" % softWareMillVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.0-M2"
   lazy val keycloakAdapterCore  = "org.keycloak" % "keycloak-adapter-core" % keycloakVersion
   lazy val keycloakCore = "org.keycloak" % "keycloak-core" % keycloakVersion
-  lazy val logger = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+  lazy val logger = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
   lazy val httpComponents = "org.apache.httpcomponents" % "httpclient" % "4.5.11"
   lazy val jbossLogging = "org.jboss.logging" % "jboss-logging" % "3.4.1.Final"
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.2.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "7.1.1"
   lazy val sttp = "com.softwaremill.sttp.client" %% "core" % softWareMillVersion
   lazy val sttpCirce = "com.softwaremill.sttp.client" %% "circe" % softWareMillVersion
-  lazy val sttpAsyncClient = "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.0.0-RC9"
+  lazy val sttpAsyncClient = "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.3.0"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   lazy val logger = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
   lazy val httpComponents = "org.apache.httpcomponents" % "httpclient" % "4.5.11"
   lazy val jbossLogging = "org.jboss.logging" % "jboss-logging" % "3.4.1.Final"
-  lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.2.0"
+  lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.11.0"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0"
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "7.1.1"
   lazy val sttp = "com.softwaremill.sttp.client" %% "core" % softWareMillVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   lazy val jbossLogging = "org.jboss.logging" % "jboss-logging" % "3.4.1.Final"
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.11.0"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0"
-  lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "7.1.1"
+  lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "7.1.3"
   lazy val sttp = "com.softwaremill.sttp.client" %% "core" % softWareMillVersion
   lazy val sttpCirce = "com.softwaremill.sttp.client" %% "circe" % softWareMillVersion
   lazy val sttpAsyncClient = "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.3.0"

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "javax.xml.bind" % "jaxb-api" % "2.3.0",
+  "javax.xml.bind" % "jaxb-api" % "2.3.1",
   "com.sun.xml.bind" % "jaxb-ri" % "2.3.0"
 )
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,4 @@
 libraryDependencies ++= Seq(
   "javax.xml.bind" % "jaxb-api" % "2.3.1",
-  "com.sun.xml.bind" % "jaxb-ri" % "2.3.0"
+  "com.sun.xml.bind" % "jaxb-ri" % "2.3.6"
 )
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 resolvers += Resolver.jcenterRepo
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/src/test/scala/uk/gov/nationalarchives/tdr/keycloak/ServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/keycloak/ServiceTest.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives.tdr.keycloak
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.tngtech.keycloakmock.api.KeycloakVerificationMock
+import com.tngtech.keycloakmock.api.{KeycloakMock, ServerConfig}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, EitherValues}
 
@@ -11,8 +11,11 @@ import scala.concurrent.ExecutionContext
 class ServiceTest extends AnyFlatSpec with BeforeAndAfterEach with BeforeAndAfterAll with EitherValues {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
-
-  val mock: KeycloakVerificationMock = new KeycloakVerificationMock(9050, "tdr")
+  val serverConfig: ServerConfig = ServerConfig.aServerConfig()
+    .withPort(9050)
+    .withDefaultRealm("tdr")
+    .build()
+  val mock: KeycloakMock = new KeycloakMock(serverConfig)
   val port = 9050
   val url = s"http://localhost:$port/auth"
   val utils: KeycloakUtils = KeycloakUtils()


### PR DESCRIPTION
- Update sbt-release to 1.0.15
- Update wiremock-jre8 to 2.26.3
- Update oauth2-oidc-sdk to 7.1.3
- Update async-http-client-backend-future to 2.3.0
- Update client:circe, client:core to 2.3.0
- Update jaxb-ri to 2.3.6
- Update mock to 0.11.0
- Update scala-logging to 3.9.4
- Update circe-core, circe-generic to 0.14.1
- Update jaxb-api to 2.3.1
