### PR TITLE
Remove unused dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val root = (project in file("."))
       oauth2,
       sttp,
       sttpCirce,
-      sttpAsyncClient,
       circeCore,
       circeGeneric,
       keycloakMock % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,6 @@ object Dependencies {
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "9.35"
   lazy val sttp = "com.softwaremill.sttp.client3" %% "core" % softWareMillVersion
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % softWareMillVersion
-  lazy val sttpAsyncClient = "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.3.0"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
 }


### PR DESCRIPTION
We're not using this and it's causing this CVE
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37137
