### PR TITLE
Only auto deploy on closure of pulls into master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - master
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Under current setup any pulls into a development branch, or branch for collating dependency updates, will trigger a release. We probably only want to do this when the base branch is master, as we do in, eg, [tdr-file-metadata](https://github.com/nationalarchives/tdr-file-metadata/blob/d3383262d025dc0dc3d917287ee07cae03937a73/.github/workflows/build.yml#L6)